### PR TITLE
msspoly -> string method

### DIFF
--- a/@msspoly/display.m
+++ b/@msspoly/display.m
@@ -5,40 +5,4 @@ function display(p)
 
 % AM 09.01.09
 
-if isempty(p)
-    fprintf('   Empty msspoly matrix: %d-by-%d\n',p.dim(1),p.dim(2));
-    return
-end
-
-S{p.dim(1),p.dim(2)}=[];             % strings of entries
-
-ns = size(p.sub,1);
-
-for i=1:ns,
-    ii=p.sub(i,1);
-    jj=p.sub(i,2);
-    S{ii,jj}=msspoly.term_to_string(S{ii,jj},[p.var(i,:) p.pow(i,:) p.coeff(i,:)]);
-end
-
-L=zeros(1,p.dim(2));
-for i=1:p.dim(2),
-    L(i)=3;
-    for j=1:p.dim(1),
-        k=length(S{j,i});
-        if k==0,
-            S{j,i}=' 0';
-        else
-            L(i)=max(L(i),k);
-        end
-    end
-end
-fprintf('\n')
-for i=1:p.dim(1),
-    fprintf('[  ');
-    for j=1:p.dim(2),
-        fprintf('%s%s  ',repmat(' ',1,L(j)-length(S{i,j})),S{i,j});
-    end
-    fprintf(']\n');
-end
-fprintf('\n')
-        
+fprintf(['\n', msspoly2str(p),'\n\n']);

--- a/@msspoly/msspoly2str.m
+++ b/@msspoly/msspoly2str.m
@@ -1,0 +1,45 @@
+function str = msspoly2str(p)
+% str =  msspoly2str(p) - Returns a string, str,  representing the msspoly, p.
+%
+
+if isempty(p)
+    str = sprintf('   Empty msspoly matrix: %d-by-%d\n',p.dim(1),p.dim(2));
+    return
+end
+
+S{p.dim(1),p.dim(2)}=[];             % strings of entries
+
+ns = size(p.sub,1);
+
+for i=1:ns,
+    ii=p.sub(i,1);
+    jj=p.sub(i,2);
+    S{ii,jj}=msspoly.term_to_string(S{ii,jj},[p.var(i,:) p.pow(i,:) p.coeff(i,:)]);
+end
+
+L=zeros(1,p.dim(2));
+for i=1:p.dim(2),
+    L(i)=3;
+    for j=1:p.dim(1),
+        k=length(S{j,i});
+        if k==0,
+            S{j,i}=' 0';
+        else
+            L(i)=max(L(i),k);
+        end
+    end
+end
+str = [];
+
+for i=1:p.dim(1),
+    if i>1
+      str = sprintf('%s\n',str);
+    end
+    str_i = [];
+    for j=1:p.dim(2),
+        str_i = [str_i,sprintf('%s%s  ',repmat(' ',1,L(j)-length(S{i,j})),S{i,j})];
+    end
+    str = [str, sprintf('[  %s]',str_i)];
+end
+        
+


### PR DESCRIPTION
This pull-request decouples creating a string that represents an `msspoly` from displaying that string. The former is handled by a new method `msspoly2str`, which is called by `msspoly/display`. This separation allows users to incorporate strings representing `msspoly`s into their own output.
